### PR TITLE
fix(stats): prevent panic on multiple prometheus instances

### DIFF
--- a/stats/statsprometheus.go
+++ b/stats/statsprometheus.go
@@ -1,7 +1,14 @@
 package stats
 
 import (
+	"sync"
+
 	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	prometheusCounterVec *prometheus.CounterVec
+	registerOnce         sync.Once
 )
 
 var _ Handler = (*Prometheus)(nil)
@@ -9,8 +16,7 @@ var _ Handler = (*Prometheus)(nil)
 type (
 	Prometheus struct {
 		PrometheusOptions
-		cacheName  string
-		counterVec *prometheus.CounterVec
+		cacheName string
 	}
 
 	PrometheusOptions struct {
@@ -56,51 +62,52 @@ func NewPrometheus(cacheName string, opts ...PrometheusOption) *Prometheus {
 		opt(&o)
 	}
 
-	vec := prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: o.namespace,
-			Subsystem: o.subsystem,
-			Name:      o.name,
-			Help:      o.help,
-		}, []string{"cache_name", "cache_type", "method", "err"},
-	)
-	prometheus.MustRegister(vec)
+	registerOnce.Do(func() {
+		prometheusCounterVec = prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: o.namespace,
+				Subsystem: o.subsystem,
+				Name:      o.name,
+				Help:      o.help,
+			}, []string{"cache_name", "cache_type", "method", "err"},
+		)
+		prometheus.MustRegister(prometheusCounterVec)
+	})
 
 	return &Prometheus{
 		PrometheusOptions: o,
 		cacheName:         cacheName,
-		counterVec:        vec,
 	}
 }
 
 func (s *Prometheus) IncrHit() {
-	s.counterVec.WithLabelValues(s.cacheName, "total", "hit", "").Inc()
+	prometheusCounterVec.WithLabelValues(s.cacheName, "total", "hit", "").Inc()
 }
 
 func (s *Prometheus) IncrMiss() {
-	s.counterVec.WithLabelValues(s.cacheName, "total", "miss", "").Inc()
+	prometheusCounterVec.WithLabelValues(s.cacheName, "total", "miss", "").Inc()
 }
 
 func (s *Prometheus) IncrLocalHit() {
-	s.counterVec.WithLabelValues(s.cacheName, "local", "hit", "").Inc()
+	prometheusCounterVec.WithLabelValues(s.cacheName, "local", "hit", "").Inc()
 }
 
 func (s *Prometheus) IncrLocalMiss() {
-	s.counterVec.WithLabelValues(s.cacheName, "local", "miss", "").Inc()
+	prometheusCounterVec.WithLabelValues(s.cacheName, "local", "miss", "").Inc()
 }
 
 func (s *Prometheus) IncrRemoteHit() {
-	s.counterVec.WithLabelValues(s.cacheName, "remote", "hit", "").Inc()
+	prometheusCounterVec.WithLabelValues(s.cacheName, "remote", "hit", "").Inc()
 }
 
 func (s *Prometheus) IncrRemoteMiss() {
-	s.counterVec.WithLabelValues(s.cacheName, "remote", "miss", "").Inc()
+	prometheusCounterVec.WithLabelValues(s.cacheName, "remote", "miss", "").Inc()
 }
 
 func (s *Prometheus) IncrQuery() {
-	s.counterVec.WithLabelValues(s.cacheName, "query", "query", "").Inc()
+	prometheusCounterVec.WithLabelValues(s.cacheName, "query", "query", "").Inc()
 }
 
 func (s *Prometheus) IncrQueryFail(err error) {
-	s.counterVec.WithLabelValues(s.cacheName, "query", "queryFail", err.Error()).Inc()
+	prometheusCounterVec.WithLabelValues(s.cacheName, "query", "queryFail", err.Error()).Inc()
 }

--- a/stats/statsprometheus_test.go
+++ b/stats/statsprometheus_test.go
@@ -19,38 +19,45 @@ func TestPrometheus(t *testing.T) {
 	assert.Equal(t, "test_name", p.name)
 	assert.Equal(t, "test_help", p.help)
 
-	assert.Equal(t, 0, testutil.CollectAndCount(p.counterVec))
+	assert.Equal(t, 0, testutil.CollectAndCount(prometheusCounterVec))
 
 	p.IncrHit()
-	assert.Equal(t, 1, testutil.CollectAndCount(p.counterVec))
-	assert.Equal(t, float64(1), testutil.ToFloat64(p.counterVec.WithLabelValues("test_cache", "total", "hit", "")))
+	assert.Equal(t, 1, testutil.CollectAndCount(prometheusCounterVec))
+	assert.Equal(t, float64(1), testutil.ToFloat64(prometheusCounterVec.WithLabelValues("test_cache", "total", "hit", "")))
 
 	p.IncrMiss()
-	assert.Equal(t, 2, testutil.CollectAndCount(p.counterVec))
-	assert.Equal(t, float64(1), testutil.ToFloat64(p.counterVec.WithLabelValues("test_cache", "total", "miss", "")))
+	assert.Equal(t, 2, testutil.CollectAndCount(prometheusCounterVec))
+	assert.Equal(t, float64(1), testutil.ToFloat64(prometheusCounterVec.WithLabelValues("test_cache", "total", "miss", "")))
 
 	p.IncrLocalHit()
-	assert.Equal(t, 3, testutil.CollectAndCount(p.counterVec))
-	assert.Equal(t, float64(1), testutil.ToFloat64(p.counterVec.WithLabelValues("test_cache", "local", "hit", "")))
+	assert.Equal(t, 3, testutil.CollectAndCount(prometheusCounterVec))
+	assert.Equal(t, float64(1), testutil.ToFloat64(prometheusCounterVec.WithLabelValues("test_cache", "local", "hit", "")))
 
 	p.IncrLocalMiss()
-	assert.Equal(t, 4, testutil.CollectAndCount(p.counterVec))
-	assert.Equal(t, float64(1), testutil.ToFloat64(p.counterVec.WithLabelValues("test_cache", "local", "miss", "")))
+	assert.Equal(t, 4, testutil.CollectAndCount(prometheusCounterVec))
+	assert.Equal(t, float64(1), testutil.ToFloat64(prometheusCounterVec.WithLabelValues("test_cache", "local", "miss", "")))
 
 	p.IncrRemoteHit()
-	assert.Equal(t, 5, testutil.CollectAndCount(p.counterVec))
-	assert.Equal(t, float64(1), testutil.ToFloat64(p.counterVec.WithLabelValues("test_cache", "remote", "hit", "")))
+	assert.Equal(t, 5, testutil.CollectAndCount(prometheusCounterVec))
+	assert.Equal(t, float64(1), testutil.ToFloat64(prometheusCounterVec.WithLabelValues("test_cache", "remote", "hit", "")))
 
 	p.IncrRemoteMiss()
-	assert.Equal(t, 6, testutil.CollectAndCount(p.counterVec))
-	assert.Equal(t, float64(1), testutil.ToFloat64(p.counterVec.WithLabelValues("test_cache", "remote", "miss", "")))
+	assert.Equal(t, 6, testutil.CollectAndCount(prometheusCounterVec))
+	assert.Equal(t, float64(1), testutil.ToFloat64(prometheusCounterVec.WithLabelValues("test_cache", "remote", "miss", "")))
 
 	p.IncrQuery()
-	assert.Equal(t, 7, testutil.CollectAndCount(p.counterVec))
-	assert.Equal(t, float64(1), testutil.ToFloat64(p.counterVec.WithLabelValues("test_cache", "query", "query", "")))
+	assert.Equal(t, 7, testutil.CollectAndCount(prometheusCounterVec))
+	assert.Equal(t, float64(1), testutil.ToFloat64(prometheusCounterVec.WithLabelValues("test_cache", "query", "query", "")))
 
 	p.IncrQueryFail(assert.AnError)
-	assert.Equal(t, 8, testutil.CollectAndCount(p.counterVec))
+	assert.Equal(t, 8, testutil.CollectAndCount(prometheusCounterVec))
 	assert.Equal(t, float64(1),
-		testutil.ToFloat64(p.counterVec.WithLabelValues("test_cache", "query", "queryFail", assert.AnError.Error())))
+		testutil.ToFloat64(prometheusCounterVec.WithLabelValues("test_cache", "query", "queryFail", assert.AnError.Error())))
+}
+
+func TestNewPrometheus_MultipleInstances(t *testing.T) {
+	assert.NotPanics(t, func() {
+		NewPrometheus("test_cache_1")
+		NewPrometheus("test_cache_2")
+	})
 }


### PR DESCRIPTION
Refactored `NewPrometheus` to use a singleton for Prometheus metric registration, preventing panics when creating multiple instances for different caches.

- Introduced a package-level `sync.Once` to ensure metric vectors are registered with Prometheus only once.
- The `cacheName` is now used as a label to distinguish metrics from different cache instances.
- Added a unit test to verify that creating multiple `Prometheus` instances does not cause a panic.

Fixes #1